### PR TITLE
Fix bug #44, bindestrek

### DIFF
--- a/crowbot/apiai_connection/crowbot_chat.py
+++ b/crowbot/apiai_connection/crowbot_chat.py
@@ -202,8 +202,16 @@ def ask_apiai(text):
     elif response["result"]["metadata"]["intentName"] == "Default Fallback Intent":
         #legge til spørsmål i Questions modell
         question = response["result"]["resolvedQuery"]
-        words = re.compile('\w+').findall(question)
+        # om spørsmålet slutter med '?', fjern dette
+        if question.strip().endswith('?'):
+            question = question.strip()[:-1]
+        # fjerner ',' og '.' fra setningen
+        question = question.replace(',','')
+        question = question.replace('.','')
+        # splitter setningen til en liste med ord
+        words = question.split()
         code = ''
+        # går igjennom ordene for å finne emnekoden
         for word in words:
             # antagelse om at alle emnekoder begynner med bokstaver og slutter med tall
             # og at bruker bare skriver inn en emnekode i hver "spørring"


### PR DESCRIPTION
Koden håndterer nå emnekoder med bindestrek, f.eks. IMT3950-2, når det dannes en liste med ord for å finne hva som er emnekoden. 
Mulig det finnes et fancy regex uttrykk som håndterer dette, men koden fungerer som tenkt nå, de casene som har blitt testet av meg vertafall.