### PR TITLE
Increase crowbotchat code efficiency

### DIFF
--- a/crowbot/apiai_connection/crowbot_chat.py
+++ b/crowbot/apiai_connection/crowbot_chat.py
@@ -219,10 +219,6 @@ def ask_apiai(text):
             if code.lower() not in lemmas1:
                 lemmas1.append(code.lower())
             lemmas_pickled = pickle.dumps(lemmas1)
-            # for å finne spm i databasen bruker 5,70 s, 6,66 s (intet likt spm), 5.55 s
-            # for q in Question.objects.all():
-
-            # bruker 4,30 s, 4,13 s, 5,30 s (intet likt spm), 4,23 s
             for q in Question.objects.filter(course = course):
                 #ta inn lemma fra question
                 lemmas2 = pickle.loads(q.lemma)

--- a/crowbot/apiai_connection/crowbot_chat.py
+++ b/crowbot/apiai_connection/crowbot_chat.py
@@ -219,7 +219,11 @@ def ask_apiai(text):
             if code.lower() not in lemmas1:
                 lemmas1.append(code.lower())
             lemmas_pickled = pickle.dumps(lemmas1)
-            for q in Question.objects.all():
+            # for å finne spm i databasen bruker 5,70 s, 6,66 s (intet likt spm), 5.55 s
+            # for q in Question.objects.all():
+
+            # bruker 4,30 s, 4,13 s, 5,30 s (intet likt spm), 4,23 s
+            for q in Question.objects.filter(course = course):
                 #ta inn lemma fra question
                 lemmas2 = pickle.loads(q.lemma)
                 result = jaccard_similarity(lemmas1,lemmas2)

--- a/crowbot/crowbot/settings.py
+++ b/crowbot/crowbot/settings.py
@@ -81,6 +81,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'CONN_MAX_AGE': 1,
     }
 }
 


### PR DESCRIPTION
Forbedret svar effektiviteten til crowbot chat. Istedet for å gå gjennom alle spm i databasen (som nå ligger på over 36 000...), filtrerer heller spørsmål basert på emnet brukeren spør om og leter gjennom disse. Dette økte effektiviteten med ca 1 sekund. Det som gjorde utslaget var når CONN_MAX_AGE ble satt til 1 sekund i settings filen. 
"Django opens a connection to the database when it first makes a database query. It keeps this connection open and reuses it in subsequent requests. Django closes the connection once it exceeds the maximum age defined by CONN_MAX_AGE or when it isn’t usable any longer."
Av default var denne satt til 0 og tilkoblingen ble derfor åpnet og lukket mange flere ganger enn nødvendig. Nå ligger svartiden til første spørsmål etter at serveren er startet på ca 4,5 sekund og alle spørsmål etter der får svar ila. ca 1 sekund 😃 